### PR TITLE
Check casting to ChunkCache

### DIFF
--- a/src/main/java/coloredlightscore/src/helper/CLBlockHelper.java
+++ b/src/main/java/coloredlightscore/src/helper/CLBlockHelper.java
@@ -17,16 +17,20 @@ public class CLBlockHelper {
         Block block = blockAccess.getBlock(x, y, z);
         if (blockAccess instanceof World)
             l = CLWorldHelper.getLightBrightnessForSkyBlocks((World) blockAccess, x, y, z, block.getLightValue(blockAccess, x, y, z));
-        else
+        else if(blockAccess instanceof ChunkCache)
             l = CLChunkCacheHelper.getLightBrightnessForSkyBlocks((ChunkCache) blockAccess, x, y, z, block.getLightValue(blockAccess, x, y, z));
+        else
+            l = 0;
 
         if (l == 0 && block instanceof BlockSlab) {
             --y;
             block = blockAccess.getBlock(x, y, z);
             if (blockAccess instanceof World)
                 return CLWorldHelper.getLightBrightnessForSkyBlocks((World) blockAccess, x, y, z, block.getLightValue(blockAccess, x, y, z));
-            else
+            else if(blockAccess instanceof ChunkCache)
                 return CLChunkCacheHelper.getLightBrightnessForSkyBlocks((ChunkCache) blockAccess, x, y, z, block.getLightValue(blockAccess, x, y, z));
+            else
+                return 0;
         } else {
             return l;
         }


### PR DESCRIPTION
This code assumed that every IBlockAccess is either a World or a ChunkCache. StarMiner has a "DummyRotatedBlockAccess" that's a separate implementation of IBlockAccess, and when this code tries to run on it it crashes. This returns a default value of 0 when neither known IBlockAccess type is applicable, presumably causing minor visual weirdness with mods that have custom IBlockAccesses, but not crashing the game.
