### PR TITLE
[1.7.10] Changed powered lamps to use the same display name as non-powered lamps.

### DIFF
--- a/src/main/java/yamhaven/easycoloredlights/blocks/CLLamp.java
+++ b/src/main/java/yamhaven/easycoloredlights/blocks/CLLamp.java
@@ -58,6 +58,11 @@ public class CLLamp extends CLBlock {
     public IIcon getIcon(int side, int meta) {
         return icons[meta];
     }
+    
+    @Override
+    public String getUnlocalizedName() {
+        return "tile." + BlockInfo.CLLamp;
+    }
 
     @SideOnly(Side.CLIENT)
     public Item getItem(World world, int x, int y, int z) {


### PR DESCRIPTION
While the unlocalized name for the powered lamps are typically never used, there are several mods such as NEI and Waila which attempt to make use of the powered lamp's unlocalized name. By overriding this method, the powered lamp will use the same unlocalized name as it's non-powered counterpart. This follows suit with the vanilla lamp, and also resolves the issue of a broken language key being used within NEI and Waila. 
![powered](https://cloud.githubusercontent.com/assets/2250798/8719438/fb248bf2-2b68-11e5-977f-a92d97b97c6b.png)
